### PR TITLE
fix[MAV-277]:increased csv size limit for download

### DIFF
--- a/packages/python/accern_data/accern_data.py
+++ b/packages/python/accern_data/accern_data.py
@@ -1,5 +1,4 @@
 import csv
-import sys
 import io
 import os
 import time

--- a/packages/python/accern_data/accern_data.py
+++ b/packages/python/accern_data/accern_data.py
@@ -144,7 +144,10 @@ ALL_MODES: Set[ModeType] = {"csv", "df", "json"}
 
 T = TypeVar('T')
 
-MAX_VALUE = 10000000 #constant value to increase the download limit of the csv. if the limit is still less, change this value for csv.field_size_limit
+MAX_VALUE = 10000000 
+#constant value to increase the download limit of the csv. 
+# if the limit is still less, change this value for csv.field_size_limit
+
 class Mode(Generic[T]):
     def __init__(self) -> None:
         self._cur_date: Optional[str] = None

--- a/packages/python/accern_data/accern_data.py
+++ b/packages/python/accern_data/accern_data.py
@@ -144,7 +144,7 @@ ALL_MODES: Set[ModeType] = {"csv", "df", "json"}
 
 T = TypeVar('T')
 
-
+MAX_VALUE = 10000000 #constant value to increase the download limit of the csv. if the limit is still less, change this value for csv.field_size_limit
 class Mode(Generic[T]):
     def __init__(self) -> None:
         self._cur_date: Optional[str] = None
@@ -247,7 +247,7 @@ class CSVMode(Mode[pd.DataFrame]):
         self._chunk_size = chunk_size
         self._buffer: List[pd.DataFrame] = []
         self._buffer_size = 0
-        csv.field_size_limit(sys.maxsize)
+        csv.field_size_limit(MAX_VALUE)
 
     def get_format(self) -> str:
         return "csv"

--- a/packages/python/accern_data/accern_data.py
+++ b/packages/python/accern_data/accern_data.py
@@ -1,4 +1,5 @@
 import csv
+import sys
 import io
 import os
 import time
@@ -246,6 +247,7 @@ class CSVMode(Mode[pd.DataFrame]):
         self._chunk_size = chunk_size
         self._buffer: List[pd.DataFrame] = []
         self._buffer_size = 0
+        csv.field_size_limit(sys.maxsize)
 
     def get_format(self) -> str:
         return "csv"

--- a/packages/python/accern_data/accern_data.py
+++ b/packages/python/accern_data/accern_data.py
@@ -144,9 +144,10 @@ ALL_MODES: Set[ModeType] = {"csv", "df", "json"}
 
 T = TypeVar('T')
 
-MAX_VALUE = 10000000 
-#constant value to increase the download limit of the csv. 
+MAX_CSV_FIELD_SIZE = 10000000
+# constant value to increase the download limit of the csv.
 # if the limit is still less, change this value for csv.field_size_limit
+
 
 class Mode(Generic[T]):
     def __init__(self) -> None:
@@ -250,7 +251,7 @@ class CSVMode(Mode[pd.DataFrame]):
         self._chunk_size = chunk_size
         self._buffer: List[pd.DataFrame] = []
         self._buffer_size = 0
-        csv.field_size_limit(MAX_VALUE)
+        csv.field_size_limit(MAX_CSV_FIELD_SIZE)
 
     def get_format(self) -> str:
         return "csv"


### PR DESCRIPTION
## What does this PR do?
increases the csv size limit for download
TODO (If this is a bug fix, explain what was causing the issue)
MAV-277
## Changes
increased the csv download limit
- [ ] TODO

## Before reviewing

- [x] Did you test this PR?
- yes
- [ ] Is there any migration or seeding necessary?
- [ ] If a new field is added to signals in the api, did you update the sample test files?

### Links: 

- Jira: https://myaccern.atlassian.net/browse/RSL-000
